### PR TITLE
fix: blob spec in UCAN 0.9 parlance

### DIFF
--- a/did-mailto.md
+++ b/did-mailto.md
@@ -134,7 +134,7 @@ This DID Method does not support updating the DID Document.
 [did method]: https://w3c-ccg.github.io/did-spec/#specific-did-method-schemes
 [did-core]: https://w3c-ccg.github.io/did-spec/
 [did document]: https://www.w3.org/TR/did-core/#dfn-did-documents
-[did:key]: https://w3c-ccg.github.io/did-method-key/
+[did:key]: https://w3c-ccg.github.io/did-key-spec/
 [did:web]: https://w3c-ccg.github.io/did-method-web/
 [did:dns]: https://danubetech.github.io/did-method-dns/
 [email address]: https://www.rfc-editor.org/rfc/rfc2822.html#section-3.4.1

--- a/w3-access.md
+++ b/w3-access.md
@@ -560,7 +560,7 @@ Alice wants to share access to her [space] with her friend Bob. She does not kno
 
 When Bob runs the `w3up` agent the first time and authorizes as `bob@gmail.com`, the program invokes the [access claim] capability and collects all capabilities available to the account, including the one sent by Alice, gaining access to her space.
 
-[`did:key`]: https://w3c-ccg.github.io/did-method-key/
+[`did:key`]: https://w3c-ccg.github.io/did-key-spec/
 [UCAN]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md
 [UCAN Receipt]:https://github.com/ucan-wg/invocation/tree/f28f682bcb484cb515785b2a268d8a5b4cfc2b58#225-receipt
 [IPLD]: https://ipld.io/

--- a/w3-account.md
+++ b/w3-account.md
@@ -224,7 +224,7 @@ Examples
 [PKI]:https://en.wikipedia.org/wiki/Public_key_infrastructure
 [UCAN]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md
 [`did:mailto`]:./did-mailto.md
-[`did:key`]:https://w3c-ccg.github.io/did-method-key/
+[`did:key`]:https://w3c-ccg.github.io/did-key-spec/
 [principal]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md#321-principals
 <!-- markdown-link-check-disable -->
 <!-- stackexchange 403s this, presumably to prevent bot scraping -->

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -1,6 +1,6 @@
 # W3 Blob Protocol
 
-![status:wip](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square)
+![reliable](https://img.shields.io/badge/status-reliable-green.svg?style=flat-square)
 
 ## Authors
 

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -912,6 +912,6 @@ Receipt MUST NOT have any effects.
 [DID]:https://www.w3.org/TR/did-core/
 [Link]:https://ipld.io/docs/schemas/features/links/
 [range request]:https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
-[`did:key`]:https://w3c-ccg.github.io/did-method-key/
+[`did:key`]:https://w3c-ccg.github.io/did-key-spec/
 [Ed25519]:https://en.wikipedia.org/wiki/EdDSA#Ed25519
 [UCAN Conclusion]:./w3-ucan.md#conclusion

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -126,7 +126,7 @@ Shown Invocation example illustrates Alice requesting to add 2MiB blob to her sp
   "aud": "did:web:up.storacha.network",
   "att": [{
     "can": "space/blob/add",
-    "with": "did:key:zAlice",
+    "with": "did:key:zAliceSpace",
     "nb": {
       "blob": {
         // multihash of the blob as byte array
@@ -604,7 +604,7 @@ Shown Invocation example illustrates Alice requesting a page of the list of blob
   "aud": "did:web:up.storacha.network",
   "att": [{
     "can": "space/blob/list",
-    "with": "did:key:zAlice",
+    "with": "did:key:zAliceSpace",
     "nb": {
       // cursor where to start listing from
       "cursor": "cursor-value-from-previous-invocation",
@@ -714,7 +714,7 @@ Shown Invocation example illustrates Alice requesting to remove a blob stored on
   "aud": "did:web:up.storacha.network",
   "att": [{
     "can": "space/blob/remove",
-    "with": "did:key:zAlice",
+    "with": "did:key:zAliceSpace",
     "nb": {
       // multihash of the blob as byte array
       "digest": { "/": { "bytes": "mEi...sfKg" } }
@@ -808,7 +808,7 @@ Shown Invocation example illustrates Alice getting a blob stored in their space:
   "aud": "did:web:up.storacha.network",
   "att": [{
     "can": "space/blob/get/0/1",
-    "with": "did:key:zAlice",
+    "with": "did:key:zAliceSpace",
     "nb": {
       // multihash of the blob as byte array
       "digest": { "/": { "bytes": "mEi...sfKg" } },

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -910,3 +910,5 @@ Receipt MUST NOT have any effects.
 [`did:key`]:https://w3c-ccg.github.io/did-key-spec/
 [Ed25519]:https://en.wikipedia.org/wiki/EdDSA#Ed25519
 [UCAN Conclusion]:./w3-ucan.md#conclusion
+[principal]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md#321-principals
+[UCAN]:https://github.com/ucan-wg/spec/blob/692e8aab59b763a783fe1484131c3f40d997b69a/README.md

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -245,7 +245,7 @@ Invocation MUST fail if any of the following is true
 
 Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to [ucan/await] of the task that produces a [location commitment].
 
-Task linked from the `site` of the success value MUST be present in the receipt effects _(`next` field)_.
+Task linked from the `site` of the success value MUST be present in the receipt effects _(`fx` field)_.
 
 #### Add Blob Effects
 

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -2,9 +2,6 @@
 
 ![status:wip](https://img.shields.io/badge/status-wip-orange.svg?style=flat-square)
 
-- [Irakli Gozalishvili](https://github.com/gozala)
-- [Vasco Santos](https://github.com/vasco-santos)
-
 ## Authors
 
 - [Irakli Gozalishvili](https://github.com/gozala)

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -28,12 +28,12 @@ W3 blob protocol provides core building block for storing content and sharing ac
 
 There are several distinct roles that [principal]s may assume in this specification:
 
-| Name        | Description                                                                                                                                    |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Principal | The general class of entities that interact with a UCAN. Identified by a DID that can be used in the `iss` or `aud` field of a UCAN. |
-| Agent       | A [Principal] identified by [`did:key`] identifier, representing a user in an application. |
-| Issuer | A [principal] delegating capabilities to another [principal]. It is the signer of the [UCAN]. Specified in the `iss` field of a UCAN. |
-| Audience | Principal access is shared with. Specified in the `aud` field of a UCAN. |
+| Name        | Description                                                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Principal   | The general class of entities that interact with a UCAN. Identified by a DID that can be used in the `iss` or `aud` field of a UCAN.  |
+| Agent       | A [Principal] identified by [`did:key`] identifier, representing a user in an application.                                            |
+| Issuer      | A [principal] delegating capabilities to another [principal]. It is the signer of the [UCAN]. Specified in the `iss` field of a UCAN. |
+| Audience    | Principal access is shared with. Specified in the `aud` field of a UCAN.                                                              |
 
 ### Space
 
@@ -47,37 +47,37 @@ Blob is a fixed size byte array addressed by the [multihash]. Usually blobs are 
 
 ## Add Blob
 
-Authorized agent MAY invoke `/space/content/add/blob` capability on the [space] subject to store specific byte array.
+Authorized agent MAY invoke `space/blob/add` capability on the [space] subject to store specific byte array.
 
 > Note that storing a blob does not imply advertising it on the network or making it publicly available.
 
 ### Add Blob Diagram
 
-Following diagram illustrates execution flow. Alice invokes `/space/content/add/blob` command which produces a receipt with three effects (`allocate`, `put`, `accept`) and awaited `site` commitment. Effects have dependencies and therefore predict execution flow (from left to right). The output of the main task awaits on the result of the last effect.
+The following diagram illustrates execution flow. Alice invokes a `space/blob/add` command which produces a receipt with three effects (`allocate`, `put`, `accept`) and an awaited `site` commitment. Effects have dependencies and therefore predict execution flow (from left to right). The output of the main task awaits on the result of the last effect.
 
 ```mermaid
 flowchart TB
-Add("⏯️ /space/content/add/blob 👩‍💻 🤖")
+Add("⏯️ space/blob/add 👩‍💻 🤖")
 AddOk("🧾 { ok: { site } }")
 
 
 subgraph accept
-Accept("⏯️ /service/blob/accept 🤖")
+Accept("⏯️ blob/accept 🤖")
 AcceptOk("🧾 { ok: { site } }")
 end
 
 subgraph put
-Put("⏯️ /http/put 🔑")
+Put("⏯️ http/put 🔑")
 PutOk("🧾 { ok: {} }")
 end
 
 
 subgraph allocate
-Allocate("⏯️ /service/blob/allocate 🤖")
+Allocate("⏯️ blob/allocate 🤖")
 AllocateOk("🧾 { ok: { url headers } }")
 end
 
-Site("🎫 /assert/location 🤖👩‍💻")
+Site("🎫 assert/location 🤖👩‍💻")
 
 
 
@@ -118,127 +118,57 @@ AcceptOk -- site --> Site
 
 Shown Invocation example illustrates Alice requesting to add 2MiB blob to her space.
 
-```js
+> ℹ️ Note: we use `// "/": "bafy..` comments to denote CID of the parent object.
+
+```jsonc
 { // "/": "bafy..add"
-  "cmd": "/space/content/add/blob",
-  "sub": "did:key:zAlice",
   "iss": "did:key:zAlice",
-  "aud": "did:web:web3.storage",
-  "args": {
-    "blob": {
-      // multihash of the blob as byte array
-      "digest": { "/": { "bytes": "mEi...sfKg" } },
-      // size of the blob in bytes
-      "size": 2_097_152,
+  "aud": "did:web:up.storacha.network",
+  "att": [{
+    "can": "space/blob/add",
+    "with": "did:key:zAlice",
+    "nb": {
+      "blob": {
+        // multihash of the blob as byte array
+        "digest": { "/": { "bytes": "mEi...sfKg" } },
+        // size of the blob in bytes
+        "size": 2097152
+      }
     }
-  }
+  }]
 }
 ```
 
 ### Add Blob Receipt Example
 
-Shows an example receipt for the above `/space/content/add/blob` capability invocation.
+Shows an example receipt for the above `space/blob/add` capability invocation.
 
-> ℹ️ We use `// "/": "bafy..` comments to denote CID of the parent object.
-
-```js
-{ // "/": "bafy..work",
-  "iss": "did:web:web3.storage",
-  "aud": "did:key:zAlice",
-  "cmd": "/ucan/assert",
-  "sub": "did:web:web3.storage",
-  "args": {
-    "assert": [
-      // refers to the invocation from the example
-      { "/": "bafy..add" },
-      // refers to the receipt corresponding to the above invocation
-      {
-        "out": {
-          "ok": {
-            // result of the add is the content (location) commitment
-            // that is produced as result of "bafy..accept"
-            "site": {
-              "ucan/await": [
-                ".out.ok.site",
-                { "/": "bafy...accept" }
-              ]
-            }
-          }
-        },
-        // Previously `next` was known as `fx` instead, which is
-        // set of tasks to be scheduled.
-        "next": [
-          // 1. System attempts to allocate memory in user space for the blob.
-          { // "/": "bafy...alloc",
-            "cmd": "/service/blob/allocate",
-            "sub": "did:web:web3.storage",
-            "args": {
-              // space where memory is allocated
-              "space": "did:key:zAlice",
-              "blob": {
-                // multihash of the blob as byte array
-                "digest": { "/": { "bytes": "mEi...sfKg" } },
-                // size of the blob in bytes
-                "size": 2_097_152,
-              },
-              // task that caused this invocation
-              "cause": { "/": "bafy..add" }
-            }
-          },
-          // 2. System requests user agent (or anyone really) to upload the content
-          // corresponding to the blob
-          // via HTTP PUT to given location.
-          { // "/": "bafy...put",
-            "cmd": "/http/put",
-            "sub": "did:key:zMh...der", // <-- Ed299.. derived key from content multihash
-            "args": {
-              // pipe url from the allocation result
-              "url": {
-                  "ucan/await": [
-                    ".out.ok.address.url",
-                    { "/": "bafy...alloc" }
-                  ]
-              },
-              // pipe headers from the allocation result 
-              "headers": {
-                "ucan/await": [
-                  ".out.ok.address.headers",
-                  { "/": "bafy...alloc" }
-                ]
-              },
-              // body of the http request
-              "body": {
-                // multihash of the blob as byte array
-                "digest": { "/": { "bytes": "mEi...sfKg" } },
-                "size": 2_097_152
-              },
-            },
-            "meta": {
-              // archive of the principal keys
-              "keys": {
-                "did:key:zMh...der": { "/": "mEi...sfKg" } 
-              }
-            }
-          },
-          // 3. System will attempt to accept uploaded content that matches blob
-          // multihash and size.
-          { // "/": "bafy...accept",
-            "cmd": "/service/blob/accept",
-            "sub": "did:web:web3.storage",
-            "args": {
-              "space": "did:key:zAlice",
-              "blob": {
-                // multihash of the blob as byte array
-                "content": { "/": { "bytes": "mEi...sfKg" } },
-                "size": 2_097_152,
-              },
-              "expires": 1712903125,
-              // This task is blocked on allocation
-              "_put": { "ucan/await": [".out.ok", { "/": "bafy...put" }] }
-            }
-          }
+```jsonc
+{
+  "ran": "bafy..add",
+  "out": {
+    "ok": {
+      // Result of the add is the content (location) commitment that is produced
+      // as result of "bafy..accept"
+      "site": {
+        "ucan/await": [
+          ".out.ok.site",
+          { "/": "bafy...accept" }
         ]
       }
+    }
+  },
+  // Async tasks to be scheduled.
+  "fx": {
+    "fork": [
+      // 1. System attempts to allocate memory in user space for the blob.
+      { "/": "bafy...alloc" },
+      // 2. System requests user agent (or anyone really) to upload the content
+      // corresponding to the blob via HTTP PUT to given location.
+      { "/": "bafy...put" },
+      // 3. System will attempt to accept uploaded content that matches blob
+      // multihash and size.
+      { "/": "bafy...accept" }
     ]
   }
 }
@@ -250,16 +180,16 @@ Shows an example receipt for the above `/space/content/add/blob` capability invo
 
 ```ts
 type AddBlob = {
-  cmd: "/space/content/add/blob"
-  sub: SpaceDID
-  args: {
+  can: "space/blob/add"
+  with: SpaceDID
+  nb: {
     blob: Blob
   }
 }
 
 type Blob = {
-  digest:   Multihash
-  size:     int
+  digest: Multihash
+  size: int
 }
 
 type Multihash = bytes
@@ -268,27 +198,30 @@ type SpaceDID = string
 
 #### Blob Digest
 
-The `args.blob.digest` field MUST be a [multihash] digest of the blob payload bytes. Implementation SHOULD support SHA2-256 algorithm. Implementation MAY in addition support other hashing algorithms.
+The `nb.blob.digest` field MUST be a [multihash] digest of the blob payload bytes. Implementation SHOULD support SHA2-256 algorithm. Implementation MAY in addition support other hashing algorithms.
 
 #### Blob Size
 
-Blob `args.blob.size` field MUST be set to the number of bytes in the blob content.
+Blob `nb.blob.size` field MUST be set to the number of bytes in the blob content.
 
 ### Add Blob Receipt
 
 #### Add Blob Receipt Schema
 
 ```ts
-// Only operation specific fields are covered the
-// rest are implied
+// Only operation specific fields are covered the rest are implied
 type AddBlobReceipt = {
   out: Result<AddBlobOk, AddBlobError>
-  next: [
-    AllocateBlob,
-    PutBlob,
-    AcceptBlob,
-  ]
+  fx: {
+    fork: [
+      Link<AllocateBlob>,
+      Link<PutBlob>,
+      Link<AcceptBlob>,
+    ]
+  }
 }
+
+type Result<Ok, Err> = { ok: Ok } | { error: Err }
 
 type AddBlobOk = {
   site: {
@@ -305,12 +238,12 @@ type AddBlobError = {
 
 Invocation MUST fail if any of the following is true
 
-1. Provided **sub**ject space is not provisioned with a provider.
+1. Provided subject space is not provisioned with a provider.
 1. Provided `blob.size` is outside of supported range.
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
 
-Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to [ucan/await] of the task that produces [location commitment].
+Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to [ucan/await] of the task that produces a [location commitment].
 
 Task linked from the `site` of the success value MUST be present in the receipt effects _(`next` field)_.
 
@@ -324,35 +257,60 @@ Successful invocation MUST start a workflow consisting of following tasks, that 
 
 ## Allocate Blob
 
-Authorized agent MAY invoke `/service/blob/allocate` capability on the [provider] subject to create a memory address where `blob` content can be written via HTTP `PUT` request.
+An authorized agent MAY invoke `blob/allocate` capability on a storage provider to create a memory address where the `blob` content can be written via a HTTP `PUT` request.
 
 ### Allocate Blob Capability
+
+Example:
+
+```jsonc
+{ // "/": "bafy...alloc",
+  "iss": "did:web:up.storacha.network",
+  "aud": "did:key:zStorageProvider",
+  "att": [{
+    "can": "blob/allocate",
+    "with": "did:key:zStorageProvider",
+    "nb": {
+      // space where memory is allocated
+      "space": { "/": { "bytes": "did:key:zAlice" } },
+      "blob": {
+        // multihash of the blob as byte array
+        "digest": { "/": { "bytes": "mEi...sfKg" } },
+        // size of the blob in bytes
+        "size": 2097152,
+      },
+      // task that caused this invocation
+      "cause": { "/": "bafy..add" }
+    }
+  }]
+}
+```
 
 #### Allocate Blob Capability Schema
 
 ```ts
 type BlobAllocate = {
-  cmd:  "/service/blob/allocate"
-  sub:  ProviderDID
-  args: {
-    space:  SpaceDID
-    blob:   Blob
-    cause:  Link<AddBlob>
+  can: "blob/allocate"
+  with: ProviderDID
+  nb: {
+    space: Bytes<SpaceDID>
+    blob: Blob
+    cause: Link<AddBlob>
   }
 }
 ```
 
 #### Allocation Space
 
-The `args.space` field MUST be set to the [DID] of the user space where allocation takes place.
+The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space where allocation takes place.
 
 #### Allocation Blob
 
-The `args.blob` field MUST be set to the `Blob` the space is allocated for.
+The `nb.blob` field MUST be set to the `Blob` the space is allocated for.
 
 #### Allocation Cause
 
-The `args.cause` field MUST be set to the [Link] for the [Add Blob] task, that caused an allocation.
+The `nb.cause` field MUST be set to the [Link] for the [Add Blob] task, that caused an allocation.
 
 ### Allocate Blob Receipt
 
@@ -364,7 +322,6 @@ Allocations MUST fail if `space` does not have enough capacity for the `blob` an
 type BlobAllocateReceipt = {
   ran:  Link<BlobAllocate>
   out:  Result<BlobAllocateOk, BlobAllocateError>
-  next: []
 }
 
 type BlobAllocateOk = {
@@ -373,10 +330,10 @@ type BlobAllocateOk = {
 }
 
 type BlobAddress = {
-  url:     string
-  headers: {[key:string]: string}
-  # Unix timestamp (in seconds precision) of when this address expires
-  expires  Int
+  url: string
+  headers: { [key: string]: string }
+  // Unix timestamp (in seconds precision) of when this address expires
+  expires: int
 }
 ```
 
@@ -384,12 +341,12 @@ type BlobAddress = {
 
 The `out.ok.size` MUST be set to the number of bytes that were allocated for the `Blob`. It MUST be equal to either:
 
-1. The `args.blob.size` of the invocation.
-2. `0` if space already has memory allocated for the `args.blob`.
+1. The `nb.blob.size` of the invocation.
+2. `0` if the storage node already has memory allocated for the `nb.blob`.
 
 ### Allocation Address
 
-The optional `out.ok.address` SHOULD be omitted when content for the allocated is already available on site. Otherwise it MUST be set to the `BlobAddress` that can receive a blob content.
+The optional `out.ok.address` SHOULD be omitted when content for the allocated blob is already available on site. Otherwise it MUST be set to the `BlobAddress` that can receive a blob content.
 
 The `url` of the `BlobAddress` MUST be an HTTP(S) location that can receive blob content via HTTP `PUT` request, as long as HTTP headers from `headers` dictionary are set on the request.
 
@@ -403,28 +360,67 @@ Allocation MUST have no effects.
 
 ## Put Blob
 
-Any agent MAY perform `/http/put` capability invocation on behalf of the subject. [Add blob] capability provider MUST add `/http/put` effect and capture private key of the `subject` in the `meta` field so that any agent could perform it.
+Any agent MAY perform `http/put` capability invocation on behalf of the subject. The [add blob] capability provider MUST add a `http/put` effect and capture the private key of the `subject` in the `facts` field so that any agent can perform it.
 
-An agent that invoked [add blob] capability is expected to perform this task and issue receipt on completion.
+The agent that invoked [add blob] capability is expected to perform this task and issue receipt on completion.
 
 ### Put Blob Capability
 
-#### Put Blob Capability Schema
+Example:
 
-> ℹ️ These examples use UCAN 1.0.0-rc.1. In UCAN 0.9, [`meta`](https://github.com/ucan-wg/spec/tree/1c64556f15574af80022bf38b6f4b3125696eae9?tab=readme-ov-file#metadata) is known as [`fct`](https://github.com/ucan-wg/spec/tree/692e8aab59b763a783fe1484131c3f40d997b69a?tab=readme-ov-file#324-facts).
+```jsonc
+{ // "/": "bafy...put",
+  "iss": "did:key:zMh...der", // <-- Ed299.. derived key from content multihash
+  "aud": "did:key:zMh...der",
+  "att": [{
+    "can": "http/put",
+    "with": "did:key:zMh...der",
+    "nb": {
+      // pipe url from the allocation result
+      "url": {
+        "ucan/await": [
+          ".out.ok.address.url",
+          { "/": "bafy...alloc" }
+        ]
+      },
+      // pipe headers from the allocation result 
+      "headers": {
+        "ucan/await": [
+          ".out.ok.address.headers",
+          { "/": "bafy...alloc" }
+        ]
+      },
+      // body of the http request
+      "body": {
+        // multihash of the blob as byte array
+        "digest": { "/": { "bytes": "mEi...sfKg" } },
+        "size": 2097152
+      }
+    }
+  }],
+  "fct": [{
+    // archive of the principal keys
+    "keys": {
+      "did:key:zMh...der": { "/": { "bytes": "mEi...sfKg" } }
+    }
+  }]
+}
+```
+
+#### Put Blob Capability Schema
 
 ```ts
 type BlobPut = {
-  cmd: "/http/put"
-  sub: DID
-  args: {
+  can: "http/put"
+  with: DID
+  nb: {
     url: URL
     headers: Headers
     body: Blob
   }
-  meta: {
+  fct: [{
     keys: {[key: DID]: bytes}
-  }
+  }]
 }
 ```
 
@@ -432,7 +428,7 @@ type BlobPut = {
 
 The subject field SHOULD be [`did:key`] corresponding to the [Ed25519] private key that is last 32 bytes of the blob [multihash].
 
-### Put Blob Metadata
+### Put Blob Facts
 
 Metadata MUST contain `keys` field with an object value that contains [`did:key`] subject as key and corresponding private key bytes as a value.
 
@@ -460,12 +456,11 @@ Receipt is signal to the service to proceed with [accept blob]. Service implemen
 type BlobPutReceipt = {
   ran: Link<BlobPut>
   out: Result<BlobPutOk, BlobPutError>
-  next: []
 }
 
 type BlobPutOk = {}
 
-type AddPutError = {
+type BlobPutError = {
   message: string
 }
 ```
@@ -476,7 +471,7 @@ Receipt MUST not have any effects.
 
 ## Accept Blob
 
-Authorized agent MAY invoke `/service/blob/accept` capability on the [provider] subject. Invocation MUST either succeed when content is delivered at allocated site or fail if either allocation failed or expired before content was delivered.
+Authorized agent MAY invoke `blob/accept` capability on the storage provider. Invocation MUST either succeed when content is delivered at allocated site or fail if either allocation failed or expired before content was delivered.
 
 Invocation MUST block until content is delivered. Implementation MAY resume when content is sent to the allocated address or await until client signals that content has been delivered using [put blob receipt].
 
@@ -484,15 +479,38 @@ Invocation MUST block until content is delivered. Implementation MAY resume when
 
 ### Accept Blob Capability
 
+Example:
+
+```jsonc
+{ // "/": "bafy...accept",
+  "iss": "did:web:up.storacha.network",
+  "aud": "did:key:zStorageProvider",
+  "att": [{
+    "can": "blob/accept",
+    "with": "did:key:zStorageProvider",
+    "nb": {
+      "space": { "/": { "bytes": "did:key:zAlice" } },
+      "blob": {
+        // multihash of the blob as byte array
+        "content": { "/": { "bytes": "mEi...sfKg" } },
+        "size": 2097152,
+      },
+      // This task is blocked on blob put
+      "_put": { "ucan/await": [".out.ok", { "/": "bafy...put" }] }
+    }
+  }]
+}
+```
+
 #### Accept Blob Capability Schema
 
 ```ts
 type BlobAccept = {
-  cmd: "/service/blob/accept"
-  sub: ProviderDID
-  args: {
+  can: "blob/accept"
+  with: ProviderDID
+  nb: {
+    space: Bytes<SpaceDID>
     blob: Blob
-    exp: int
   }
 }
 ```
@@ -505,7 +523,6 @@ type BlobAccept = {
 type BlobAcceptReceipt = {
   ran: Link<BlobAccept>
   out: Result<BlobAcceptOk, BlobAcceptError>
-  next: []
 }
 
 type BlobAcceptOk = {
@@ -523,106 +540,106 @@ Receipt MUST not have any effects.
 
 ## Location Commitment
 
-Location commitment represents commitment from the issuer to the audience that
-content matching the `content` [multihash] can be read via HTTP [range request]
+Location commitment represents a commitment from the issuer to the audience that content matching the `content` [multihash] can be read via a HTTP [range request].
 
-### Location Commitment Delegation Example
+### Location Commitment Capability
 
-```js
+Example:
+
+```jsonc
 {
-  "iss": "did:web:web3.storage",
+  "iss": "did:key:zStorageProvider",
   "aud": "did:key:zAlice",
-
-  "cmd": "/assert/location",
-  "sub": "did:web:web3.storage",
-  "pol": [
-    // multihash must match be for the blob uploaded
-    ["==", ".content", { "/": { "bytes": "mEi...sfKg" } }],
-    // must be available from this url
-    ["==", ".url", "https://w3s.link/ipfs/bafk...7fi"],
-    // from this range
-    ["==", ".range[0]", 0],
-    ["==", ".range[1]", 2_097_152],
-  ],
+  "att": [{
+    "can": "assert/location",
+    "with": "did:key:zStorageProvider",
+    "nb": {
+      // space the content was added to
+      "space": { "/": { "bytes": "did:key:zAlice" } },
+      // multihash must match be for the blob uploaded
+      "content": { "/": { "bytes": "mEi...sfKg" } },
+      // must be available from this url
+      "url": "https://storage-provider.example.com/blob/zQm...",
+      // from this range
+      "range": {
+        "offset": 0,
+        "length": 2097152
+      }
+    }
+  }],
   // does not expire
   "exp": null
 }
 ```
 
-### Location Commitment Capability
-
 #### Location Commitment Capability Schema
 
 ```ts
 type LocationCommitment = {
-  cmd: "/assert/location"
-  sub: ProviderDID
-  args: {
+  can: "assert/location"
+  with: ProviderDID
+  nb: {
+    space: SpaceDID
     content: Multihash
     url: string
-    range: [start:int, end:int, ...int[]]
+    range?: {
+      offset: int
+      length?: int
+    }
   }
 }
 ```
 
 ## List Blob
 
-Authorized agent MAY invoke `/space/content/list/blob` capability on the [space] subject (`sub` field) to list Blobs added to it at the time of invocation.
+Authorized agent MAY invoke `/space/blob/list` capability on the [space] subject (`with` field) to list Blobs added to it at the time of invocation.
 
 ### List Blob Invocation Example
 
 Shown Invocation example illustrates Alice requesting a page of the list of blobs stored on their space.
 
-```js
-{
-  "cmd": "/space/content/list/blob",
-  "sub": "did:key:zAlice",
+```jsonc
+{ // "/": "bafy..list",
   "iss": "did:key:zAlice",
-  "aud": "did:web:web3.storage",
-  "args": {
-    // cursor where to start listing from
-    "cursor": 'cursor-value-from-previous-invocation',
-    // size of page
-    "size": 40,
-  }
+  "aud": "did:web:up.storacha.network",
+  "att": [{
+    "can": "space/blob/list",
+    "with": "did:key:zAlice",
+    "nb": {
+      // cursor where to start listing from
+      "cursor": "cursor-value-from-previous-invocation",
+      // size of page
+      "size": 40
+    }
+  }]
 }
 ```
 
 ### List Blob Receipt Example
 
-Shows an example receipt for the above `/space/content/list/blob` capability invocation.
+An example receipt for the above `space/blob/list` capability invocation:
 
-> ℹ️ We use `// "/": "bafy..` comments to denote CID of the parent object.
-
-```js
-{ // "/": "bafy..list",
-  "iss": "did:web:web3.storage",
-  "aud": "did:key:zAlice",
-  "cmd": "/ucan/assert/result"
-  "sub": "did:web:web3.storage",
-  "args": {
-    // refers to the invocation from the example
-    "ran": { "/": "bafy..list" },
-    "out": {
-      "ok": {
-        // cursor where to start listing from on next call
-        "cursor": "cursor-value-for-next-invocation",
-        // size of the list
-        "size": 40,
-        "results": [
-          {
-            "insertedAt": "2024-04-16T15:49:22.638Z",
-            "blob": {
-              "size": 100,
-              "content": { "/": { "bytes": "mEi...sfKg" } },
-            }
-          },
-          // ...
-        ]
-      }
-    },
-    // set of tasks to be scheduled.
-    "next": []
+```jsonc
+{ // "/": "bafy..list"
+  // refers to the invocation from the example
+  "ran": { "/": "bafy..list" },
+  "out": {
+    "ok": {
+      // cursor where to start listing from on next call
+      "cursor": "cursor-value-for-next-invocation",
+      // size of the list
+      "size": 40,
+      "results": [
+        {
+          "insertedAt": "2024-04-16T15:49:22.638Z",
+          "blob": {
+            "size": 100,
+            "content": { "/": { "bytes": "mEi...sfKg" } },
+          }
+        }
+        // ...
+      ]
+    }
   }
 }
 ```
@@ -633,9 +650,9 @@ Shows an example receipt for the above `/space/content/list/blob` capability inv
 
 ```ts
 type ListBlob = {
-  cmd: "/space/content/list/blob"
-  sub: SpaceDID
-  args: {
+  can: "space/blob/list"
+  with: SpaceDID
+  nb: {
     cursor?: string
     size?: number
   }
@@ -644,11 +661,11 @@ type ListBlob = {
 
 ##### List Cursor
 
-The optional `args.cursor` MAY be specified in order to paginate over the list of the added Blobs.
+The optional `nb.cursor` MAY be specified in order to paginate over the list of the added Blobs.
 
 ##### List Size
 
-The optional `args.size` MAY be specified to signal desired page size, that is number of items in the result.
+The optional `nb.size` MAY be specified to signal desired page size, that is number of items in the result.
 
 ### List Blob Receipt
 
@@ -657,7 +674,6 @@ The optional `args.size` MAY be specified to signal desired page size, that is n
 ```ts
 type ListBlobReceipt = {
   out: Result<ListBlobOk, ListBlobError>
-  next: []
 }
 
 type ListBlobOk = {
@@ -686,48 +702,40 @@ Receipt MUST not have any effects.
 
 ## Remove Blob
 
-Authorized agent MAY invoke `/space/content/remove/blob` capability to remove content archive from the subject space (`sub` field).
+Authorized agent MAY invoke `space/blob/remove` capability to remove content archive from the subject space (`with` field).
 
 ### Remove Blob Invocation Example
 
-Shown Invocation example illustrates Alice requesting to remove a blob stored on their space.
+Shown Invocation example illustrates Alice requesting to remove a blob stored on their space:
 
-```js
-{
-  "cmd": "/space/content/remove/blob",
-  "sub": "did:key:zAlice",
+```jsonc
+{ // "/": "bafy..remove"
   "iss": "did:key:zAlice",
-  "aud": "did:web:web3.storage",
-  "args": {
-    // multihash of the blob as byte array
-    "digest": { "/": { "bytes": "mEi...sfKg" } },
-  }
+  "aud": "did:web:up.storacha.network",
+  "att": [{
+    "can": "space/blob/remove",
+    "with": "did:key:zAlice",
+    "nb": {
+      // multihash of the blob as byte array
+      "digest": { "/": { "bytes": "mEi...sfKg" } }
+    }
+  }]
 }
 ```
 
 ### Remove Blob Receipt Example
 
-Shows an example receipt for the above `/space/content/remove/blob` capability invocation.
+An example receipt for the above `space/blob/remove` capability invocation:
 
-> ℹ️ We use `// "/": "bafy..` comments to denote CID of the parent object.
-
-```js
-{ // "/": "bafy..remove",
-  "iss": "did:web:web3.storage",
-  "aud": "did:key:zAlice",
-  "cmd": "/ucan/assert/result"
-  "sub": "did:web:web3.storage",
-  "args": {
-    // refers to the invocation from the example
-    "ran": { "/": "bafy..remove" },
-    "out": {
-      "ok": {
-        // size of the blob in bytes removed from space
-        "size": 2_097_152,
-      }
-    },
-    // set of tasks to be scheduled.
-    "next": []
+```jsonc
+{
+  // refers to the invocation from the example
+  "ran": { "/": "bafy..remove" },
+  "out": {
+    "ok": {
+      // size of the blob in bytes removed from space
+      "size": 2097152
+    }
   }
 }
 ```
@@ -738,9 +746,9 @@ Shows an example receipt for the above `/space/content/remove/blob` capability i
 
 ```ts
 type RemoveBlob = {
-  cmd: "/space/content/remove/blob"
-  sub: SpaceDID
-  args: {
+  can: "space/blob/remove"
+  with: SpaceDID
+  nb: {
     digest: Multihash
   }
 }
@@ -751,7 +759,7 @@ type SpaceDID = string
 
 ##### Remove Digest
 
-The `args.digest` field MUST be a [multihash] digest of the blob payload bytes. Implementation SHOULD support SHA2-256 algorithm. Implementation MAY in addition support other hashing algorithms.
+The `nb.digest` field MUST be a [multihash] digest of the blob payload bytes. Implementation SHOULD support SHA2-256 algorithm. Implementation MAY in addition support other hashing algorithms.
 
 ### Remove Blob Receipt
 
@@ -760,7 +768,6 @@ The `args.digest` field MUST be a [multihash] digest of the blob payload bytes. 
 ```ts
 type RemoveBlobReceipt = {
   out: Result<RemoveBlobOk, RemoveBlobError>
-  next: []
 }
 
 type RemoveBlobOk = {
@@ -774,7 +781,7 @@ type RemoveBlobError = {
 
 ##### Remove blob Size
 
-The `out.ok.size` MUST be set to the number of bytes that were freed from the space. It MUST be equal to either:
+The `nb.ok.size` MUST be set to the number of bytes that were freed from the space. It MUST be equal to either:
 
 1. The size of the Blob in bytes.
 2. `0` if specified blob is not in space.
@@ -785,7 +792,7 @@ Receipt MUST not have any effects.
 
 ## Get Blob
 
-Authorized agent MAY invoke `/space/content/get/blob/0/1` capability on the [space] subject (`sub` field) to get Blobs added to it at the time of invocation.
+Authorized agent MAY invoke `space/blob/get/0/1` capability on the [space] subject (`with` field) to get Blobs added to it at the time of invocation.
 
 This may be used to check for inclusion, or to get the `size` of the blob in bytes.
 
@@ -793,47 +800,41 @@ Note: In the future, we will likely deprecate this capability in favor of a suff
 
 ### Get Blob Invocation Example
 
-Shown Invocation example illustrates Alice getting a blob stored on their space.
+Shown Invocation example illustrates Alice getting a blob stored in their space:
 
-> ℹ️ We use `// "/": "bafy..` comments to denote CID of the parent object.
-
-```js
+```jsonc
 { // "/": "bafy..get"
-  "cmd": "/space/content/get/blob/0/1",
-  "sub": "did:key:zAlice",
   "iss": "did:key:zAlice",
-  "aud": "did:web:web3.storage",
-  "args": {
-    // multihash of the blob as byte array
-    "digest": { "/": { "bytes": "mEi...sfKg" } },
-  }
+  "aud": "did:web:up.storacha.network",
+  "att": [{
+    "can": "space/blob/get/0/1",
+    "with": "did:key:zAlice",
+    "nb": {
+      // multihash of the blob as byte array
+      "digest": { "/": { "bytes": "mEi...sfKg" } },
+    }
+  }]
 }
 ```
 
 ### Get Blob Receipt Example
 
-Shows an example receipt for the above `/space/content/get/blob/0/1` capability invocation.
+An example receipt for the above `space/blob/get/0/1` capability invocation:
 
-```js
+```jsonc
 {
-  "iss": "did:web:web3.storage",
-  "aud": "did:key:zAlice",
-  "cmd": "/ucan/assert/result"
-  "sub": "did:web:web3.storage",
-  "args": {
-    // refers to the invocation from the example
-    "ran": { "/": "bafy..get" },
-    "out": {
-      "ok": {
-        // task that caused this invocation
-        "cause": { "/": "bafy..task" }
-        "blob": {
-          "size": 100,
-          "content": { "/": { "bytes": "mEi...sfKg" } },
-        }
-      }
-    },
-    "next": []
+  // refers to the invocation from the example
+  "ran": { "/": "bafy..get" },
+  "out": {
+    "ok": {
+      "blob": {
+        "digest": { "/": { "bytes": "mEi...sfKg" } },
+        "size": 100
+      },
+      // task that caused this blob to be stored
+      "cause": { "/": "bafy..task" },
+      "insertedAt": "2024-04-16T15:49:22.638Z"
+    }
   }
 }
 ```
@@ -844,9 +845,9 @@ Shows an example receipt for the above `/space/content/get/blob/0/1` capability 
 
 ```ts
 type GetBlob = {
-  cmd: "/space/content/get/blob/0/1"
-  sub: SpaceDID
-  args: {
+  can: "space/blob/get/0/1"
+  with: SpaceDID
+  nb: {
     digest: Multihash
   }
 }
@@ -857,7 +858,7 @@ type SpaceDID = string
 
 ##### Get Digest
 
-The `args.digest` field MUST be a [multihash] digest of the blob payload bytes. Implementation SHOULD support SHA2-256 algorithm. Implementation MAY in addition support other hashing algorithms.
+The `nb.digest` field MUST be a [multihash] digest of the blob payload bytes. Implementation SHOULD support SHA2-256 algorithm. Implementation MAY in addition support other hashing algorithms.
 
 ### Get Blob Receipt
 
@@ -866,12 +867,12 @@ The `args.digest` field MUST be a [multihash] digest of the blob payload bytes. 
 ```ts
 type GetBlobReceipt = {
   out: Result<GetBlobOk, GetBlobError>
-  next: []
 }
 
 type GetBlobOk = {
-  cause:  Link<Task>
   blob: Blob
+  cause: Link<AddBlob>
+  insertedAt: ISO8601Date
 }
 
 type ISO8601Date = string
@@ -890,19 +891,12 @@ type Multihash = bytes
 
 #### Get Cause
 
-The `args.cause` field MUST be set to the [Link] for the task, that caused a get.
+The `nb.cause` field MUST be set to the [Link] for the task, that caused the blob to be added.
 
 ##### Get Blob Effects
 
 Receipt MUST NOT have any effects.
 
-# Coordination
-
-## Publishing Blob
-
-Blob can be published by authorizing read interface (e.g. IPFS gateway) by delegating it [Location Commitment] that has been obtained from the provider.
-
-> Note that same applies to publishing blob on [IPNI], new capability is not necessary, user simply needs to re-delegate `LocationCommitment` to the DID representing [IPNI] publisher. [IPNI] publisher in turn may publish delegation to DID with publicly known private key allowing anyone to perform the reads.
 
 [store protocol]:./w3-store.md
 [CAR]:https://ipld.io/specs/transport/car/
@@ -910,7 +904,7 @@ Blob can be published by authorizing read interface (e.g. IPFS gateway) by deleg
 [space]:#space
 [IPNI]:https://github.com/ipni/specs/blob/main/IPNI.md
 [location commitment]:#location-commitment
-[Add Blob]:#add-blob
+[add Blob]:#add-blob
 [Put Blob]:#put-blob
 [put blob receipt]:#put-blob-receipt
 [Allocate Blob]:#allocate-blob

--- a/w3-blob.md
+++ b/w3-blob.md
@@ -897,12 +897,10 @@ The `nb.cause` field MUST be set to the [Link] for the task, that caused the blo
 
 Receipt MUST NOT have any effects.
 
-
 [store protocol]:./w3-store.md
 [CAR]:https://ipld.io/specs/transport/car/
 [multihash]:https://github.com/multiformats/multihash
 [space]:#space
-[IPNI]:https://github.com/ipni/specs/blob/main/IPNI.md
 [location commitment]:#location-commitment
 [add Blob]:#add-blob
 [Put Blob]:#put-blob

--- a/w3-filecoin.md
+++ b/w3-filecoin.md
@@ -969,7 +969,7 @@ type DealInfoDetail struct {
 ```
 
 [`did:web`]: https://w3c-ccg.github.io/did-method-web/
-[`did:key`]:https://w3c-ccg.github.io/did-method-key/
+[`did:key`]:https://w3c-ccg.github.io/did-key-spec/
 [UCAN]: https://github.com/ucan-wg/spec/
 [principal]: https://github.com/ucan-wg/spec/#321-principals
 [Protocol Labs]: https://protocol.ai/

--- a/w3-index.md
+++ b/w3-index.md
@@ -147,4 +147,4 @@ It is RECOMMENDED to bundle all the `BlobIndex`s inside the Content Archive of t
 ```
 
 [IPNI]:https://github.com/ipni/specs/blob/main/IPNI.md
-[`did:key`]:https://w3c-ccg.github.io/did-method-key/
+[`did:key`]:https://w3c-ccg.github.io/did-key-spec/

--- a/w3-provider.md
+++ b/w3-provider.md
@@ -467,7 +467,7 @@ When a space has a payment provider, its owner or delegate can invoke [`provider
 }
 ```
 
-[did:key]: https://w3c-ccg.github.io/did-method-key/
+[did:key]: https://w3c-ccg.github.io/did-key-spec/
 [ucan]: https://github.com/ucan-wg/spec/#57-revocation
 [public key cryptography]: https://en.wikipedia.org/wiki/Public-key_cryptography
 [`provider/get`]: #providerget

--- a/w3-session.md
+++ b/w3-session.md
@@ -316,7 +316,7 @@ Authorization sessions only apply to UCANs that have a [proof] linking to them. 
 - [Agent.proofs](https://github.com/web3-storage/w3up/blob/e34eed1fa3d6ef24ce2c01982764f2012dbf30d8/packages/access-client/src/agent.js#L275) is aware of w3-session proofs
 
 [`did:mailto`]: https://github.com/ucan-wg/did-mailto/
-[`did:key`]: https://w3c-ccg.github.io/did-method-key/
+[`did:key`]: https://w3c-ccg.github.io/did-key-spec/
 [ucan]: https://github.com/ucan-wg/spec/
 [principal alignment]: https://github.com/ucan-wg/spec/blob/main/README.md#62-principal-alignment
 [revocation]: https://github.com/ucan-wg/spec/#28-revocation

--- a/w3-store.md
+++ b/w3-store.md
@@ -1,6 +1,6 @@
 # W3 Storage Protocol
 
-![reliable](https://img.shields.io/badge/status-reliable-green.svg?style=flat-square)
+![deprecated](https://img.shields.io/badge/status-deprecated-red.svg?style=flat-square)
 
 ## Editors
 


### PR DESCRIPTION
This PR updates the blob spec to use UCAN 0.9 parlance - the version implemented and used in production.

[📖 Preview](https://github.com/storacha/specs/blob/fix/blob-spec-ucan-09-parlance/w3-blob.md)