### PR TITLE
feat: replication protocol

### DIFF
--- a/.github/workflows/words-to-ignore.txt
+++ b/.github/workflows/words-to-ignore.txt
@@ -175,3 +175,4 @@ InterPlanetary
 queryable
 bafy
 0-rc
+async

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -391,7 +391,6 @@ Invocation MUST succeed if non of the above is true.
 
 Receipt MUST not have any effects.
 
-
 [DID]:https://www.w3.org/TR/did-core/
 [Link]:https://ipld.io/docs/schemas/features/links/
 [multihash]:https://github.com/multiformats/multihash

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -91,7 +91,7 @@ The receipt for `space/blob/replicate` includes effects (async tasks) for `blob/
 Each replication task MUST target a _different_ replica node and they MUST NOT target the primary node.
 ``
 
-The upload service MUST select storage node(s) and allocate replication space when the `space/blob/replicate` invocation is received.
+The upload service MUST select replica node(s) and allocate replication space when the `space/blob/replicate` invocation is received.
 
 The receipt also includes effects (async tasks) and receipts for each allocation task performed.
 
@@ -183,7 +183,7 @@ The number of effects received is dependent on the number of replicas requested.
 
 ### Blob Replica Allocate
 
-The upload service allocates replication space on storage nodes by issuing a `blob/replica/allocate` invocation:
+The upload service allocates replication space on replica nodes by issuing a `blob/replica/allocate` invocation:
 
 ```json5
 {
@@ -213,7 +213,7 @@ The upload service allocates replication space on storage nodes by issuing a `bl
 }
 ```
 
-The `blob/replica/allocate` task receipt includes an async task that will be performed by the storage node: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the storage node has transferred the blob from its location to the storage node.
+The `blob/replica/allocate` task receipt includes an async task that will be performed by the replica node: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the replica node has transferred the blob from its location on the primary node.
 
 #### Blob Replica Allocate Capability Schema
 
@@ -283,7 +283,7 @@ Invocation MUST succeed if non of the above is true.
 The `out.ok.size` MUST be set to the number of bytes that were allocated for the `Blob`. It MUST be equal to either:
 
 1. The `nb.blob.size` of the invocation.
-2. `0` if the storage node already has memory allocated for the `nb.blob`.
+2. `0` if the replica node already has memory allocated for the `nb.blob`.
 
 ##### Blob Replica Allocate Effects
 
@@ -325,7 +325,7 @@ A `blob/replica/transfer` task takes the following form:
 
 When the `blob/replica/transfer` task is complete a receipt is issued. The receipt is communicated back to the upload service via a [`ucan/conclude` invocation](./w3-ucan.md#conclusion).
 
-The receipt for `blob/replica/transfer` includes a new signed location commitment from the storage node the blob has been replicated to.
+The receipt for `blob/replica/transfer` includes a new signed location commitment from the replica node the blob has been replicated to.
 
 Client can poll the upload service for the `blob/replica/transfer` receipt.
 

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -393,5 +393,5 @@ Receipt MUST not have any effects.
 
 
 [DID]:https://www.w3.org/TR/did-core/
-[Link]:(https://ipld.io/docs/schemas/features/links/)
+[Link]:https://ipld.io/docs/schemas/features/links/
 [multihash]:https://github.com/multiformats/multihash

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -1,0 +1,268 @@
+# Replication Protocol
+
+![draft](https://img.shields.io/badge/status-draft-yellow.svg?style=flat-square)
+
+## Authors
+
+- [Alan Shaw](https://github.com/alanshaw), [Storacha Network](https://storacha.network/)
+
+## Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119](https://datatracker.ietf.org/doc/html/rfc2119).
+
+## Introduction
+
+Replication ensures that if a storage node loses a blob, it remains available in the network. This specification is an extension to the blob protocol that allows nodes within the network to replicate data between each other _after_ a storage node has received an initial upload.
+
+Out of scope: This specification does not propose any solution for repairing lost data from any node.
+
+## Specification
+
+### Diagram
+
+The interactions can be summarized by the following diagram.
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant UploadService
+    participant ReplicaNode
+    participant PrimaryNode
+
+    Note over Client,UploadService: Step 1: Instruct replication
+    Client->>UploadService: space/blob/replicate (with location to fetch data)
+
+    Note over UploadService,ReplicaNode: Step 2: Allocate replication
+    UploadService->>ReplicaNode: blob/replica/allocate (with location to fetch data)
+    ReplicaNode->>UploadService: blob/replica/allocate receipt (indicates capacity reserved)
+    UploadService->>Client: space/blob/replicate receipt
+
+    Note over ReplicaNode,PrimaryNode: Step 3: Replica node “pulls” data from original
+    ReplicaNode->>PrimaryNode: Fetch content from "location" commitment
+    PrimaryNode->>ReplicaNode: Returns blob data
+
+    Note over Client,ReplicaNode: Step 4: Confirm transfer to replicate
+    ReplicaNode->>UploadService: blob/replica/transfer receipt (indicates success/failure)
+    UploadService->>Client: blob/replica/transfer receipt
+```
+
+### Blob Replicate
+
+A `space/blob/replicate` invocation instructs the upload service to replicate a blob to the specified number of storage nodes. A replication request is only valid to be issued _after_ the client has received a `blob/accept` receipt, indicating the target storage node has successfully received the blob.
+
+The caveats for `space/blob/replicate` MUST include a `replicas` parameter, an unsigned integer indicating the number of copies the network should ensure are stored _in addition_ to the original.
+
+It is RECOMMENDED that the upload service mandate a minimum _and_ a maximum value. The minimum and maximum MAY be the same.
+
+e.g. `replicas: 2` will ensure 3 copies of the data exist in the network.
+
+The blob to be replicated and the location where the blob may be found are also required.
+
+```json5
+{
+  "iss": "did:key:zAlice",
+  "aud": "did:web:upload.service.example.com",
+  "att": [
+    {
+      "with": "did:key:zAliceSpace",
+      "can": "space/blob/replicate",
+      "nb": {
+        /** The blob that MUST be replicated. */
+        "blob": {
+          "digest": { "/": { "bytes": "..." } },
+          "size": 1234
+        },
+        /** Number of replicas to ensure. */
+        "replicas": 2,
+        /** A location commitment indicating where the blob MUST be fetched from. */
+        "location": { "/": "bafy..locationCommitment" }
+      }
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+It is RECOMMENDED that the location commitment is included in the invocation.
+
+The receipt for `space/blob/replicate` includes effects (async tasks) for `blob/replica/transfer`. Successful completion of the `blob/replica/transfer` task indicates the replication target has transferred and stored the blob. The number of `blob/replica/transfer` tasks corresponds directly to number of replicas requested.
+
+Each replication task MUST target a _different_ storage node and they MUST NOT target the original upload target.
+
+The upload service MUST select storage node(s) and allocate replication space when the `space/blob/replicate` invocation is received.
+
+The reciept also includes effects (async tasks) and receipts for each allocation task performed.
+
+#### Blob Replicate Capability Schema
+
+```ts
+type ReplicateBlob = {
+  can: "space/blob/replicate"
+  with: SpaceDID
+  nb: {
+    blob: Blob
+    replicas: int
+    location: Link<LocationCommitment>
+  }
+}
+
+type Blob = {
+  digest: Multihash
+  size: int
+}
+
+type Multihash = bytes
+type SpaceDID = string
+```
+
+##### Blob
+
+The `nb.blob` field MUST be set to the `Blob` that is to be replicated.
+
+##### Replicas
+
+The `nb.replicas` field MUST be an unsigned integer indicating the number of copies the network should ensure are stored _in addition_ to the original. It MUST be greater than 0.
+
+##### Location
+
+The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/links/) to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+
+#### Blob Replicate Reciept Schema
+
+```ts
+type ReplicateBlobReceipt = {
+  out: Result<ReplicateBlobOk, ReplicateBlobError>
+  fx: {
+    fork: [
+      Link<AllocateReplicaBlob>
+      Link<TransferReplicaBlob>
+    ]
+  }
+}
+
+type Result<Ok, Err> = { ok: Ok } | { error: Err }
+
+type ReplicateBlobOk = {
+  site: [{
+    "ucan/await": [".out.ok.site", Link<TransferReplicaBlob>]
+  }]
+}
+
+type ReplicateBlobError = {
+  message: string
+}
+```
+
+##### Blob Replicate Result
+
+Invocation MUST fail if any of the following is true:
+
+1. Provided subject space is not provisioned with a provider.
+1. Provided subject space does not currently store the blob.
+1. Provided `blob.size` is outside of supported range.
+1. Provided `blob.digest` is not a valid [multihash].
+1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
+1. Provided `replicas` is not an unsigned integer greater than 0.
+1. Provided `location` commitment is invalid or has been revoked.
+
+Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment](./w3-blob.md#location-commitment), one for each replica requested.
+
+Task linked from the `site` of the success value MUST be present in the receipt effects _(`fx` field)_.
+
+##### Blob Replicate Effects
+
+Successful invocation MUST start a workflow consisting of following tasks, that MUST be set in receipt effects (`fx` field) in the following order:
+
+1. [Blob Replica Allocate](#blob-replica-allocate) (1 or more)
+1. [Blob Replica Transfer](#blob-replica-transfer) (1 or more)
+
+The number of effects recieved is dependant on the number of replicas requested.
+
+### Blob Replica Allocation
+
+The upload service allocates replication space on storage nodes by issuing a `blob/replica/allocate` invocation:
+
+```json5
+{
+  "iss": "did:web:upload.service.example.com",
+  "aud": "did:key:zStorageNode",
+  "att": [
+    {
+      "with": "did:key:zStorageNode",
+      "can": "blob/replica/allocate",
+      "nb": {
+        /** The blob that was must be replicated. */
+        "blob": {
+          "digest": { "/": { "bytes": "..." } },
+          "size": 1234
+        },
+        /** DID of the space the blob has been allocated to. */
+        "space": { "/": { "bytes": "..." } },
+        /** A location commitment indicating where the blob MUST be fetched from. */
+        "location": { "/": "bafy..locationCommitment" },
+        /** The `space/blob/replicate` invocation that caused this allocation. */
+        "cause": { "/": "bafy..replicate" }
+      }
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+The `blob/replica/allocate` task receipt includes an async task that will be performed by the storage node - `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the storage node has transferred the blob from its location to the storage node.
+
+#### Blob Replica Allocate Capability Schema
+
+TODO
+
+#### Blob Replica Allocate Reciept Schema
+
+TODO
+
+### Blob Replica Transfer
+
+The `blob/replica/transfer` task is completed by each replication node. Replication data is fetched from the location specified in the location commitment referenced by the `blob/replica/allocate` invocation.
+
+A `blob/replica/transfer` task takes the following form:
+
+```json5
+{
+  "iss": "did:key:zStorageNode",
+  "aud": "did:key:zStorageNode",
+  "att": [
+    {
+      "with": "did:key:zStorageNode",
+      "can": "blob/replica/transfer",
+      "nb": {
+        /** The blob that will be transferred. */
+        "blob": {
+          "digest": { "/": { "bytes": "..." } },
+          "size": 1234
+        },
+        /** The location the blob will be transferred from. */
+        "location": { "/": "bafy..locationCommitment" },
+        /** The `blob/replica/allocate` invocation that initiated this transfer. */
+        "cause": { "/": "bafy..allocate" }
+      }
+    }
+  ],
+  "prf": [],
+  "sig": "..."
+}
+```
+
+When the `blob/replica/transfer` task is complete a receipt is issued. The receipt is communicated back to the upload service via a `ucan/conclude` invocation.
+
+The receipt for `blob/replica/transfer` includes a new signed location commitment from the storage node the blob has been replicated to.
+
+Client can poll the upload service for the `blob/replica/transfer` receipt.
+
+#### Blob Replica Transfer Capability Schema
+
+TODO
+
+#### Blob Replica Transfer Reciept Schema
+
+TODO

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -354,7 +354,7 @@ When the `blob/replica/transfer` task is complete a receipt is issued. The _Repl
 
 The receipt for `blob/replica/transfer` MUST include a new signed location commitment from the _Replica Node_ the blob has been replicated to.
 
-The _Client_ MAY poll the _Replication Service_ for the `blob/replica/transfer` receipt in order to discover the succsfull completion or failure of the task.
+The _Client_ MAY poll the _Replication Service_ for the `blob/replica/transfer` receipt in order to discover the successfull completion or failure of the task.
 
 #### Blob Replica Transfer Capability Schema
 

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -178,7 +178,7 @@ Successful invocation MUST start a workflow consisting of following tasks, that 
 1. [Blob Replica Allocate](#blob-replica-allocate) (1 or more)
 1. [Blob Replica Transfer](#blob-replica-transfer) (1 or more)
 
-The number of effects recieved is dependent on the number of replicas requested.
+The number of effects received is dependent on the number of replicas requested.
 
 ### Blob Replica Allocate
 

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -354,7 +354,7 @@ When the `blob/replica/transfer` task is complete a receipt is issued. The _Repl
 
 The receipt for `blob/replica/transfer` MUST include a new signed location commitment from the _Replica Node_ the blob has been replicated to.
 
-The _Client_ MAY poll the _Replication Service_ for the `blob/replica/transfer` receipt in order to discover the successfull completion or failure of the task.
+The _Client_ MAY poll the _Replication Service_ for the `blob/replica/transfer` receipt in order to discover the successful completion or failure of the task.
 
 #### Blob Replica Transfer Capability Schema
 

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -12,7 +12,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Introduction
 
-Replication ensures that if a storage node loses a blob, it remains available in the network. This specification is an extension to the blob protocol that allows nodes within the network to replicate data between each other _after_ a storage node has received an initial upload.
+The Replication Protocol enables distributed storage of blobs across multiple nodes in the network. This specification extends the blob protocol by defining how nodes replicate data after initial upload. The protocol establishes four roles: '**Client**' instructs replications, '**Replication Service**' receives replication instructions and orchestrates replications, '**Primary Nodes**' receive initial uploads, and '**Replica Nodes**' store additional copies.
+
+This allows the network to maintain multiple copies of each blob, distributed across different nodes.
 
 Out of scope: This specification does not propose any solution for repairing lost data from any node.
 
@@ -25,34 +27,36 @@ The interactions can be summarized by the following diagram:
 ```mermaid
 sequenceDiagram
     participant Client
-    participant UploadService
+    participant ReplicationService
     participant ReplicaNode
     participant PrimaryNode
 
-    Note over Client,UploadService: Step 1: Instruct replication
-    Client->>UploadService: space/blob/replicate (with location to fetch data)
+    Note over Client,ReplicationService: Step 1: Instruct replication
+    Client->>ReplicationService: space/blob/replicate (with location to fetch data)
 
-    Note over UploadService,ReplicaNode: Step 2: Allocate replication
-    UploadService->>ReplicaNode: blob/replica/allocate (with location to fetch data)
-    ReplicaNode->>UploadService: blob/replica/allocate receipt (indicates capacity reserved)
-    UploadService->>Client: space/blob/replicate receipt
+    Note over ReplicationService,ReplicaNode: Step 2: Allocate replication
+    ReplicationService->>ReplicaNode: blob/replica/allocate (with location to fetch data)
+    ReplicaNode->>ReplicationService: blob/replica/allocate receipt (indicates capacity reserved)
+    ReplicationService->>Client: space/blob/replicate receipt
 
     Note over ReplicaNode,PrimaryNode: Step 3: Replica node “pulls” data from original
     ReplicaNode->>PrimaryNode: Fetch content from "location" commitment
     PrimaryNode->>ReplicaNode: Returns blob data
 
     Note over Client,ReplicaNode: Step 4: Confirm transfer to replicate
-    ReplicaNode->>UploadService: blob/replica/transfer receipt (indicates success/failure)
-    UploadService->>Client: blob/replica/transfer receipt
+    ReplicaNode->>ReplicationService: blob/replica/transfer receipt (indicates success/failure)
+    ReplicationService->>Client: blob/replica/transfer receipt
 ```
 
 ### Blob Replicate
 
-A `space/blob/replicate` invocation instructs the upload service to replicate a blob to the specified number of storage nodes. A replication request is only valid to be issued _after_ the client has received a `blob/accept` receipt, indicating the target storage node has successfully received the blob.
+A `space/blob/replicate` invocation instructs the _Replication Service_ to replicate a blob to the specified number of _Replica Nodes_. A replication request is only valid to be issued _after_ the _Client_ has received a `blob/accept` receipt, indicating the _Primary Node_ has successfully received the blob.
 
-The caveats for `space/blob/replicate` MUST include a `replicas` parameter, an unsigned integer indicating the number of copies the network should ensure are stored _in addition_ to the original.
+Any agent with authority to issue `space/blob/replicate` may invoke the capability, but it is typically the _Client_ that performed the initial upload to the _Primary Node_.
 
-It is RECOMMENDED that the upload service mandate a minimum _and_ a maximum value. The minimum and maximum MAY be the same.
+The caveats for `space/blob/replicate` MUST include a `replicas` parameter, an unsigned integer indicating the total number of copies the network should ensure are stored _in addition_ to the original.
+
+It is RECOMMENDED that the _Replication Service_ receiving the instruction mandate a minimum _and_ a maximum value. The minimum and maximum MAY be the same.
 
 e.g. `replicas: 2` will ensure 3 copies of the data exist in the network.
 
@@ -61,7 +65,7 @@ The blob to be replicated and the location where the blob may be found are also 
 ```json5
 {
   "iss": "did:key:zAlice",
-  "aud": "did:web:upload.service.example.com",
+  "aud": "did:web:replication.service.example.com",
   "att": [
     {
       "with": "did:key:zAliceSpace",
@@ -72,7 +76,7 @@ The blob to be replicated and the location where the blob may be found are also 
           "digest": { "/": { "bytes": "..." } },
           "size": 1234
         },
-        /** Number of replicas to ensure. */
+        /** Total number of replicas to ensure. */
         "replicas": 2,
         /** A location commitment indicating where the blob MUST be fetched from. */
         "site": { "/": "bafy..locationCommitment" }
@@ -84,16 +88,15 @@ The blob to be replicated and the location where the blob may be found are also 
 }
 ```
 
-It is RECOMMENDED that the location commitment is included in the invocation.
+It is RECOMMENDED that the block(s) that comprise the location commitment are included in the invocation.
 
 The receipt for `space/blob/replicate` includes effects (async tasks) for `blob/replica/transfer`. Successful completion of the `blob/replica/transfer` task indicates the replication target has transferred and stored the blob. The number of `blob/replica/transfer` tasks corresponds directly to number of replicas requested.
 
-Each replication task MUST target a _different_ replica node and they MUST NOT target the primary node.
-``
+Each replication task MUST target a _different_ _Replica Node_ and they MUST NOT target the _Primary Node_. It is RECOMMENDED that the replication tasks do not target any _Replica Nodes_ that have previously failed to replicate the data.
 
-The upload service MUST select replica node(s) and allocate replication space when the `space/blob/replicate` invocation is received.
+The _Replication Service_ MUST select _Replica Node_(s) and allocate replication space when the `space/blob/replicate` invocation is received.
 
-The receipt also includes effects (async tasks) and receipts for each allocation task performed.
+The receipt MUST include effects (async tasks) and receipts for each allocation task performed.
 
 #### Blob Replicate Capability Schema
 
@@ -123,7 +126,7 @@ The `nb.blob` field MUST be set to the `Blob` that is to be replicated.
 
 ##### Replicas
 
-The `nb.replicas` field MUST be an unsigned integer indicating the number of copies the network should ensure are stored _in addition_ to the original. It MUST be greater than 0.
+The `nb.replicas` field MUST be an unsigned integer indicating the total number of copies the network should ensure are stored _in addition_ to the original. It MUST be greater than 0.
 
 ##### Site
 
@@ -160,15 +163,14 @@ type ReplicateBlobError = {
 
 Invocation MUST fail if any of the following is true:
 
-1. Provided subject space is not provisioned with a provider.
 1. Provided subject space does not currently store the blob.
 1. Provided `blob.size` is outside of supported range.
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
-1. Provided `replicas` is not an unsigned integer greater than 0.
-1. Provided `site` is a valid, non-revoked [location commitment].
+1. Provided `replicas` is not an unsigned integer greater than 0 or is outside of any configured minimum or maximum value set by the _Replication Service_.
+1. Provided `site` is an invalid or revoked [location commitment].
 
-Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment], one for each replica requested.
+Invocation MUST succeed if none of the above are true. Success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment], one for each replica requested.
 
 Task linked from the `site` of the success value MUST be present in the receipt effects _(`fx` field)_.
 
@@ -183,11 +185,11 @@ The number of effects received is dependent on the number of replicas requested.
 
 ### Blob Replica Allocate
 
-The upload service allocates replication space on replica nodes by issuing a `blob/replica/allocate` invocation:
+The _Replication Service_ allocates replication space on _Replica Nodes_ by issuing a `blob/replica/allocate` invocation:
 
 ```json5
 {
-  "iss": "did:web:upload.service.example.com",
+  "iss": "did:web:replication.service.example.com",
   "aud": "did:key:zStorageNode",
   "att": [
     {
@@ -213,7 +215,7 @@ The upload service allocates replication space on replica nodes by issuing a `bl
 }
 ```
 
-The `blob/replica/allocate` task receipt includes an async task that will be performed by the replica node: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the replica node has transferred the blob from its location on the primary node.
+The `blob/replica/allocate` task receipt MUST include an async task that will be performed by the _Replica Node_: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the _Replica Node_ has transferred the blob from its location on the _Primary Node_.
 
 #### Blob Replica Allocate Capability Schema
 
@@ -260,9 +262,34 @@ type AllocateReplicaBlobReceipt = {
 type AllocateReplicaBlobOk = {
   /** The number of bytes allocated for a Blob. */
   size: int
+  site: { "ucan/await": [".out.ok.site", Link<TransferReplicaBlob>] }
 }
 
-type AllocateReplicaBlobError = {
+type AllocateReplicaBlobError =
+  | ReplicationCountRangeError
+  | ReplicationSourceNotFound
+  | InvalidReplicationSite
+  | Failure
+
+/** Number of replicas exceeds minimum or maximum. */
+type ReplicationCountRangeError = {
+  name: 'ReplicationCountRangeError'
+  message: string
+}
+
+/** Blob is not stored in the space. */
+type ReplicationSourceNotFound = {
+  name: 'ReplicationSourceNotFound'
+  message: string
+}
+
+/** Location commitment is invalid or revoked. */
+type InvalidReplicationSite = {
+  name: 'InvalidReplicationSite'
+  message: string
+}
+
+type Failure = {
   message: string
 }
 ```
@@ -274,9 +301,9 @@ Invocation MUST fail if any of the following is true:
 1. Provided `blob.size` is outside of supported range.
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
-1. Provided `site` is a valid, non-revoked [location commitment].
+1. Provided `site` is an invalid or revoked [location commitment].
 
-Invocation MUST succeed if non of the above is true.
+Invocation MUST succeed if none of the above are true.
 
 ###### Size
 
@@ -291,7 +318,7 @@ Successful invocation MUST start a workflow consisting of a [Transfer Replica Bl
 
 ### Blob Replica Transfer
 
-The `blob/replica/transfer` task is completed by each replication node. Replication data is fetched from the location specified in the location commitment referenced by the `blob/replica/allocate` invocation.
+The `blob/replica/transfer` task is completed by each _Replica Node_. Replication data is transferred from the location specified in the location commitment referenced by the `blob/replica/allocate` invocation.
 
 A `blob/replica/transfer` task takes the following form:
 
@@ -323,11 +350,11 @@ A `blob/replica/transfer` task takes the following form:
 }
 ```
 
-When the `blob/replica/transfer` task is complete a receipt is issued. The receipt is communicated back to the upload service via a [`ucan/conclude` invocation](./w3-ucan.md#conclusion).
+When the `blob/replica/transfer` task is complete a receipt is issued. The _Replica Node_ MUST communicate the receipt back to the _Replication Service_ via a [`ucan/conclude` invocation](./w3-ucan.md#conclusion).
 
-The receipt for `blob/replica/transfer` includes a new signed location commitment from the replica node the blob has been replicated to.
+The receipt for `blob/replica/transfer` MUST include a new signed location commitment from the _Replica Node_ the blob has been replicated to.
 
-Client can poll the upload service for the `blob/replica/transfer` receipt.
+The _Client_ MAY poll the _Replication Service_ for the `blob/replica/transfer` receipt in order to discover the succsfull completion or failure of the task.
 
 #### Blob Replica Transfer Capability Schema
 
@@ -384,9 +411,11 @@ Invocation MUST fail if any of the following is true:
 1. Provided `blob.size` is outside of supported range.
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
-1. Provided `site` is a valid, non-revoked [location commitment].
+1. Provided `site` is an invalid or revoked [location commitment].
 
-Invocation MUST succeed if non of the above is true.
+Invocation MUST succeed if none of the above are true.
+
+The transfer MAY fail for other reasons. For example, the _Primary Node_ is unreachable. When a transfer fails, it is up to the _Client_ to re-instruct replication tasks by issuing another `space/blob/replicate` invocation with a new [nonce](https://github.com/ucan-wg/spec/tree/v0.9.2#323-nonce). The receipt for which MUST include effects for existing non-failed replications and new replication tasks.
 
 #### Blob Replica Transfer Effects
 

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -75,7 +75,7 @@ The blob to be replicated and the location where the blob may be found are also 
         /** Number of replicas to ensure. */
         "replicas": 2,
         /** A location commitment indicating where the blob MUST be fetched from. */
-        "location": { "/": "bafy..locationCommitment" }
+        "site": { "/": "bafy..locationCommitment" }
       }
     }
   ],
@@ -103,7 +103,7 @@ type ReplicateBlob = {
   nb: {
     blob: Blob
     replicas: int
-    location: Link<LocationCommitment>
+    site: Link<LocationCommitment>
   }
 }
 
@@ -124,9 +124,9 @@ The `nb.blob` field MUST be set to the `Blob` that is to be replicated.
 
 The `nb.replicas` field MUST be an unsigned integer indicating the number of copies the network should ensure are stored _in addition_ to the original. It MUST be greater than 0.
 
-##### Location
+##### Site
 
-The `nb.location` field MUST be a [Link] to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+The `nb.site` field MUST be a [Link] to the [location commitment] describing where the blob can be retrieved.
 
 #### Blob Replicate Receipt Schema
 
@@ -165,9 +165,9 @@ Invocation MUST fail if any of the following is true:
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
 1. Provided `replicas` is not an unsigned integer greater than 0.
-1. Provided `location` commitment is invalid or has been revoked.
+1. Provided `site` is a valid, non-revoked [location commitment].
 
-Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment](./w3-blob.md#location-commitment), one for each replica requested.
+Invocation MUST succeed if non of the above is true. Success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment], one for each replica requested.
 
 Task linked from the `site` of the success value MUST be present in the receipt effects _(`fx` field)_.
 
@@ -201,7 +201,7 @@ The upload service allocates replication space on storage nodes by issuing a `bl
         /** DID of the space the blob has been allocated to. */
         "space": { "/": { "bytes": "..." } },
         /** A location commitment indicating where the blob MUST be fetched from. */
-        "location": { "/": "bafy..locationCommitment" },
+        "site": { "/": "bafy..locationCommitment" },
         /** The `space/blob/replicate` invocation that caused this allocation. */
         "cause": { "/": "bafy..replicate" }
       }
@@ -223,7 +223,7 @@ type AllocateReplicaBlob = {
   nb: {
     blob: Blob
     space: Bytes<SpaceDID>
-    location: Link<LocationCommitment>
+    site: Link<LocationCommitment>
     cause: Link<ReplicateBlob>
   }
 }
@@ -239,7 +239,7 @@ The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space w
 
 ##### Location
 
-The `nb.location` field MUST be a [Link] to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+The `nb.site` field MUST be a [Link] to the [location commitment] describing where the blob can be retrieved.
 
 ##### Cause
 
@@ -273,7 +273,7 @@ Invocation MUST fail if any of the following is true:
 1. Provided `blob.size` is outside of supported range.
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
-1. Provided `location` commitment is invalid or has been revoked.
+1. Provided `site` is a valid, non-revoked [location commitment].
 
 Invocation MUST succeed if non of the above is true.
 
@@ -311,7 +311,7 @@ A `blob/replica/transfer` task takes the following form:
         /** DID of the space the blob has been allocated to. */
         "space": { "/": { "bytes": "..." } },
         /** The location the blob will be transferred from. */
-        "location": { "/": "bafy..locationCommitment" },
+        "site": { "/": "bafy..locationCommitment" },
         /** The `blob/replica/allocate` invocation that initiated this transfer. */
         "cause": { "/": "bafy..allocate" }
       }
@@ -337,7 +337,7 @@ type TransferReplicaBlob = {
   nb: {
     blob: Blob
     space: Bytes<SpaceDID>
-    location: Link<LocationCommitment>
+    site: Link<LocationCommitment>
     cause: Link<AllocateReplicaBlob>
   }
 }
@@ -351,9 +351,9 @@ The `nb.blob` field MUST be set to the `Blob` the space is allocated for.
 
 The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space where allocation took place.
 
-##### Location
+##### Site
 
-The `nb.location` field MUST be a [Link] to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+The `nb.site` field MUST be a [Link] to the [location commitment] describing where the blob can be retrieved.
 
 ##### Cause
 
@@ -383,7 +383,7 @@ Invocation MUST fail if any of the following is true:
 1. Provided `blob.size` is outside of supported range.
 1. Provided `blob.digest` is not a valid [multihash].
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
-1. Provided `location` commitment is invalid or has been revoked.
+1. Provided `site` is a valid, non-revoked [location commitment].
 
 Invocation MUST succeed if non of the above is true.
 
@@ -393,4 +393,5 @@ Receipt MUST not have any effects.
 
 [DID]:https://www.w3.org/TR/did-core/
 [Link]:https://ipld.io/docs/schemas/features/links/
+[location commitment]:./w3-blob.md#location-commitment
 [multihash]:https://github.com/multiformats/multihash

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -27,9 +27,9 @@ The interactions can be summarized by the following diagram:
 ```mermaid
 sequenceDiagram
     participant Client
-    participant ReplicationService
-    participant ReplicaNode
-    participant PrimaryNode
+    participant ReplicationService as Replication Service
+    participant ReplicaNode as Replica Node
+    participant PrimaryNode as Primary Node
 
     Note over Client,ReplicationService: Step 1: Instruct replication
     Client->>ReplicationService: space/blob/replicate (with location to fetch data)

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -20,7 +20,7 @@ Out of scope: This specification does not propose any solution for repairing los
 
 ### Diagram
 
-The interactions can be summarized by the following diagram.
+The interactions can be summarized by the following diagram:
 
 ```mermaid
 sequenceDiagram
@@ -132,6 +132,7 @@ The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/l
 
 ```ts
 type ReplicateBlobReceipt = {
+  ran:  Link<ReplicateBlob>
   out: Result<ReplicateBlobOk, ReplicateBlobError>
   fx: {
     fork: [
@@ -179,7 +180,7 @@ Successful invocation MUST start a workflow consisting of following tasks, that 
 
 The number of effects recieved is dependant on the number of replicas requested.
 
-### Blob Replica Allocation
+### Blob Replica Allocate
 
 The upload service allocates replication space on storage nodes by issuing a `blob/replica/allocate` invocation:
 
@@ -215,11 +216,77 @@ The `blob/replica/allocate` task receipt includes an async task that will be per
 
 #### Blob Replica Allocate Capability Schema
 
-TODO
+```ts
+type AllocateReplicaBlob = {
+  can: "blob/replica/allocate"
+  with: StorageNodeDID
+  nb: {
+    blob: Blob
+    space: Bytes<SpaceDID>
+    location: Link<LocationCommitment>
+    cause: Link<ReplicateBlob>
+  }
+}
+```
+
+##### Blob
+
+The `nb.blob` field MUST be set to the `Blob` the space is allocated for.
+
+##### Space
+
+The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space where allocation took place.
+
+##### Location
+
+The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/links/) to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+
+##### Cause
+
+The `nb.cause` field MUST be set to the [Link] for the [Replicate Blob](#blob-replicate) task, that caused an allocation.
 
 #### Blob Replica Allocate Reciept Schema
 
-TODO
+```ts
+type AllocateReplicaBlobReceipt = {
+  ran:  Link<AllocateReplicaBlob>
+  out:  Result<AllocateReplicaBlobOk, AllocateReplicaBlobError>
+  fx: {
+    fork: [Link<TransferReplicaBlob>]
+  }
+}
+
+type AllocateReplicaBlobOk = {
+  /** The number of bytes allocated for a Blob. */
+  size: int
+}
+
+type AllocateReplicaBlobError = {
+  message: string
+}
+```
+
+##### Blob Replica Allocate Result
+
+Invocation MUST fail if any of the following is true:
+
+1. Provided `blob.size` is outside of supported range.
+1. Provided `blob.digest` is not a valid [multihash].
+1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
+1. Provided `location` commitment is invalid or has been revoked.
+
+Invocation MUST succeed if non of the above is true.
+
+###### Size
+
+The `out.ok.size` MUST be set to the number of bytes that were allocated for the `Blob`. It MUST be equal to either:
+
+1. The `nb.blob.size` of the invocation.
+2. `0` if the storage node already has memory allocated for the `nb.blob`.
+
+##### Blob Replica Allocate Effects
+
+Successful invocation MUST start a workflow consisting of a [Transfer Replica Blob](#blob-replica-transfer) task, that MUST be set in receipt effects (`fx` field).
 
 ### Blob Replica Transfer
 
@@ -241,6 +308,8 @@ A `blob/replica/transfer` task takes the following form:
           "digest": { "/": { "bytes": "..." } },
           "size": 1234
         },
+        /** DID of the space the blob has been allocated to. */
+        "space": { "/": { "bytes": "..." } },
         /** The location the blob will be transferred from. */
         "location": { "/": "bafy..locationCommitment" },
         /** The `blob/replica/allocate` invocation that initiated this transfer. */
@@ -253,7 +322,7 @@ A `blob/replica/transfer` task takes the following form:
 }
 ```
 
-When the `blob/replica/transfer` task is complete a receipt is issued. The receipt is communicated back to the upload service via a `ucan/conclude` invocation.
+When the `blob/replica/transfer` task is complete a receipt is issued. The receipt is communicated back to the upload service via a [`ucan/conclude` invocation](./w3-ucan.md#conclusion).
 
 The receipt for `blob/replica/transfer` includes a new signed location commitment from the storage node the blob has been replicated to.
 
@@ -261,8 +330,63 @@ Client can poll the upload service for the `blob/replica/transfer` receipt.
 
 #### Blob Replica Transfer Capability Schema
 
-TODO
+```ts
+type TransferReplicaBlob = {
+  can: "blob/replica/transfer"
+  with: StorageNodeDID
+  nb: {
+    blob: Blob
+    space: Bytes<SpaceDID>
+    location: Link<LocationCommitment>
+    cause: Link<AllocateReplicaBlob>
+  }
+}
+```
+
+##### Blob
+
+The `nb.blob` field MUST be set to the `Blob` the space is allocated for.
+
+##### Space
+
+The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space where allocation took place.
+
+##### Location
+
+The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/links/) to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+
+##### Cause
+
+The `nb.cause` field MUST be set to the [Link] for the [Allocate Replica Blob](#blob-replica-allocate) task, that caused an allocation.
 
 #### Blob Replica Transfer Reciept Schema
 
-TODO
+```ts
+type TransferReplicaBlobReceipt = {
+  ran: Link<TransferReplicaBlob>
+  out: Result<TransferReplicaBlobOk, TransferReplicaBlobError>
+}
+
+type TransferReplicaBlobOk = {
+  site: Link<LocationCommitment>
+}
+
+type TransferReplicaBlobError = {
+  message: string
+}
+```
+
+##### Blob Replica Transfer Result
+
+Invocation MUST fail if any of the following is true:
+
+1. Provided `blob.size` is outside of supported range.
+1. Provided `blob.digest` is not a valid [multihash].
+1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
+1. Provided `location` commitment is invalid or has been revoked.
+
+Invocation MUST succeed if non of the above is true.
+
+#### Blob Replica Transfer Effects
+
+Receipt MUST not have any effects.

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -92,7 +92,7 @@ Each replication task MUST target a _different_ storage node and they MUST NOT t
 
 The upload service MUST select storage node(s) and allocate replication space when the `space/blob/replicate` invocation is received.
 
-The reciept also includes effects (async tasks) and receipts for each allocation task performed.
+The receipt also includes effects (async tasks) and receipts for each allocation task performed.
 
 #### Blob Replicate Capability Schema
 
@@ -126,9 +126,9 @@ The `nb.replicas` field MUST be an unsigned integer indicating the number of cop
 
 ##### Location
 
-The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/links/) to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+The `nb.location` field MUST be a [Link] to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
 
-#### Blob Replicate Reciept Schema
+#### Blob Replicate Receipt Schema
 
 ```ts
 type ReplicateBlobReceipt = {
@@ -178,7 +178,7 @@ Successful invocation MUST start a workflow consisting of following tasks, that 
 1. [Blob Replica Allocate](#blob-replica-allocate) (1 or more)
 1. [Blob Replica Transfer](#blob-replica-transfer) (1 or more)
 
-The number of effects recieved is dependant on the number of replicas requested.
+The number of effects recieved is dependent on the number of replicas requested.
 
 ### Blob Replica Allocate
 
@@ -212,7 +212,7 @@ The upload service allocates replication space on storage nodes by issuing a `bl
 }
 ```
 
-The `blob/replica/allocate` task receipt includes an async task that will be performed by the storage node - `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the storage node has transferred the blob from its location to the storage node.
+The `blob/replica/allocate` task receipt includes an async task that will be performed by the storage node: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the storage node has transferred the blob from its location to the storage node.
 
 #### Blob Replica Allocate Capability Schema
 
@@ -239,13 +239,13 @@ The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space w
 
 ##### Location
 
-The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/links/) to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+The `nb.location` field MUST be a [Link] to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
 
 ##### Cause
 
 The `nb.cause` field MUST be set to the [Link] for the [Replicate Blob](#blob-replicate) task, that caused an allocation.
 
-#### Blob Replica Allocate Reciept Schema
+#### Blob Replica Allocate Receipt Schema
 
 ```ts
 type AllocateReplicaBlobReceipt = {
@@ -353,13 +353,13 @@ The `nb.space` field MUST be set to the (byte encoded) [DID] of the user space w
 
 ##### Location
 
-The `nb.location` field MUST be a [Link](https://ipld.io/docs/schemas/features/links/) to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
+The `nb.location` field MUST be a [Link] to the [location commitment](./w3-blob.md#location-commitment) describing where the blob can be retrieved.
 
 ##### Cause
 
 The `nb.cause` field MUST be set to the [Link] for the [Allocate Replica Blob](#blob-replica-allocate) task, that caused an allocation.
 
-#### Blob Replica Transfer Reciept Schema
+#### Blob Replica Transfer Receipt Schema
 
 ```ts
 type TransferReplicaBlobReceipt = {
@@ -390,3 +390,8 @@ Invocation MUST succeed if non of the above is true.
 #### Blob Replica Transfer Effects
 
 Receipt MUST not have any effects.
+
+
+[DID]:https://www.w3.org/TR/did-core/
+[Link]:(https://ipld.io/docs/schemas/features/links/)
+[multihash]:https://github.com/multiformats/multihash

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -12,7 +12,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Introduction
 
-The Replication Protocol enables distributed storage of blobs across multiple nodes in the network. This specification extends the blob protocol by defining how nodes replicate data after initial upload. The protocol establishes four roles: '**Client**' instructs replications, '**Replication Service**' receives replication instructions and orchestrates replications, '**Primary Nodes**' receive initial uploads, and '**Replica Nodes**' store additional copies.
+The Replication Protocol enables distributed storage of blobs across multiple nodes in the network. This specification extends the blob protocol by defining how nodes replicate data after initial upload. The protocol establishes four roles: **Client** instructs replications, **Replication Service** receives replication instructions and orchestrates replications, **Primary Nodes** receive initial uploads, and **Replica Nodes** store additional copies.
 
 This allows the network to maintain multiple copies of each blob, distributed across different nodes.
 
@@ -39,11 +39,11 @@ sequenceDiagram
     ReplicaNode->>ReplicationService: blob/replica/allocate receipt (indicates capacity reserved)
     ReplicationService->>Client: space/blob/replicate receipt
 
-    Note over ReplicaNode,PrimaryNode: Step 3: Replica node “pulls” data from original
-    ReplicaNode->>PrimaryNode: Fetch content from "location" commitment
+    Note over ReplicaNode,PrimaryNode: Step 3: Replica node "pulls" data from original
+    ReplicaNode->>PrimaryNode: Fetch content from "location commitment"
     PrimaryNode->>ReplicaNode: Returns blob data
 
-    Note over Client,ReplicaNode: Step 4: Confirm transfer to replicate
+    Note over Client,ReplicaNode: Step 4: Confirm transfer
     ReplicaNode->>ReplicationService: blob/replica/transfer receipt (indicates success/failure)
     ReplicationService->>Client: blob/replica/transfer receipt
 ```

--- a/w3-replication.md
+++ b/w3-replication.md
@@ -88,7 +88,8 @@ It is RECOMMENDED that the location commitment is included in the invocation.
 
 The receipt for `space/blob/replicate` includes effects (async tasks) for `blob/replica/transfer`. Successful completion of the `blob/replica/transfer` task indicates the replication target has transferred and stored the blob. The number of `blob/replica/transfer` tasks corresponds directly to number of replicas requested.
 
-Each replication task MUST target a _different_ storage node and they MUST NOT target the original upload target.
+Each replication task MUST target a _different_ replica node and they MUST NOT target the primary node.
+``
 
 The upload service MUST select storage node(s) and allocate replication space when the `space/blob/replicate` invocation is received.
 


### PR DESCRIPTION
Based on: https://github.com/storacha/RFC/pull/45

Formalizes the protocol providing invocation and receipt schemas.

There are a few differences from the RFC:

1. `space/blob/replicate` receipt:
    * Includes async tasks and receipts for `blob/allocate` in additon to `blob/transfer`.
    * Successful output includes `site: [{ "ucan/await": [".out.ok.site", Link<TransferReplicaBlob>] }]` for obtaining the location commitments for each of the replicated blobs.
2. `blob/replica/transfer` invocation includes the space DID.
3. We use `site` for field name of location claim instead of `location` for consistency with blob protocol.

[📚 Preview](https://github.com/storacha/specs/blob/feat/add-replication-protocol/w3-replication.md)