### PR TITLE
feat: `replicas` includes the original copy

### DIFF
--- a/w3-replication.md
+++ b/w3-replication.md
@@ -12,9 +12,17 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Introduction
 
-The Replication Protocol enables distributed storage of blobs across multiple nodes in the network. This specification extends the blob protocol by defining how nodes replicate data after initial upload. The protocol establishes four roles: **Client** instructs replications, **Replication Service** receives replication instructions and orchestrates replications, **Primary Nodes** receive initial uploads, and **Replica Nodes** store additional copies.
+The Replication Protocol enables distributed storage of blobs across multiple nodes in the network. This specification extends the blob protocol by defining how nodes replicate data after initial upload. The protocol establishes four roles:
+
+- The **Client** instructs replications.
+- The **Replication Service** receives replication instructions and orchestrates replications.
+- **Storage Nodes** store blob data.
+- A **Source Node** is a _Storage Node_ which already stores the blob, selected by the _Replication Service_.
+- **Replica Nodes** are _Storage Nodes_ which do not yet store the blob, selected by the _Replication Service_ to each store an additional copy.
 
 This allows the network to maintain multiple copies of each blob, distributed across different nodes.
+
+Note that a _Replica Node_ in one replication operation may later be selected as the _Source Node_ for another operation, as it will then hold a copy of the blob.
 
 Out of scope: This specification does not propose any solution for repairing lost data from any node.
 
@@ -29,38 +37,44 @@ sequenceDiagram
     participant Client
     participant ReplicationService as Replication Service
     participant ReplicaNode as Replica Node
-    participant PrimaryNode as Primary Node
+    participant SourceNode as Source Node
 
     Note over Client,ReplicationService: Step 1: Instruct replication
     Client->>ReplicationService: space/blob/replicate (with location to fetch data)
 
-    Note over ReplicationService,ReplicaNode: Step 2: Allocate replication
+    Note over ReplicationService,ReplicaNode: Step 2: Allocate replication (for each selected Replica Node)
     ReplicationService->>ReplicaNode: blob/replica/allocate (with location to fetch data)
-    ReplicaNode->>ReplicationService: blob/replica/allocate receipt (indicates capacity reserved)
-    ReplicationService->>Client: space/blob/replicate receipt
+    activate ReplicaNode
+    Note over ReplicaNode,SourceNode: Step 3: Replica node "pulls" data from original
+    ReplicaNode->>SourceNode: Fetch content from "location commitment"
+    activate SourceNode
+    ReplicaNode--)ReplicationService: blob/replica/allocate receipt (indicates capacity reserved)
+    ReplicationService--)Client: space/blob/replicate receipt
 
-    Note over ReplicaNode,PrimaryNode: Step 3: Replica node "pulls" data from original
-    ReplicaNode->>PrimaryNode: Fetch content from "location commitment"
-    PrimaryNode->>ReplicaNode: Returns blob data
+    SourceNode--)ReplicaNode: Returns blob data
+    deactivate SourceNode
 
     Note over Client,ReplicaNode: Step 4: Confirm transfer
-    ReplicaNode->>ReplicationService: blob/replica/transfer receipt (indicates success/failure)
-    ReplicationService->>Client: blob/replica/transfer receipt
+    ReplicaNode--)ReplicationService: blob/replica/transfer receipt (indicates success/failure)
+    deactivate ReplicaNode
+    ReplicationService--)Client: blob/replica/transfer receipt
 ```
 
 ### Blob Replicate
 
-A `space/blob/replicate` invocation instructs the _Replication Service_ to replicate a blob to the specified number of _Replica Nodes_. A replication request is only valid to be issued _after_ the _Client_ has received a `blob/accept` receipt, indicating the _Primary Node_ has successfully received the blob.
+A `space/blob/replicate` invocation instructs the _Replication Service_ to replicate a blob to enough _Replica Nodes_ to bring the total number of _Storage Nodes_ storing that blob to the given `replicas` number. A replication request can only be issued after some _Storage Node_ has successfully stored the blob, and the invocation must point to a `site` where it is known to exist. This can be found in the receipt of the original `blob/accept` receipt (for the original location), as well any `blob/replica/transfer` receipts from prior replications (for the additional replica locations).
 
-Any agent with authority to issue `space/blob/replicate` may invoke the capability, but it is typically the _Client_ that performed the initial upload to the _Primary Node_.
+Typically, for a given blob, `space/blob/replicate` is issued once, by the _Client_ which originally issued `space/blob/add` to store the blob, after the consequent `blob/accept` effect is complete.
 
-The caveats for `space/blob/replicate` MUST include a `replicas` parameter, an unsigned integer indicating the total number of copies the network should ensure are stored _in addition_ to the original.
+The resource (`with`) of the invocation is the space containing the blob, on whose behalf the replicas will also be stored.
+
+The caveats MUST include a `blob` parameter, identifying the blob the service should ensure is replicated.
+
+The caveats MUST include a `replicas` parameter, an unsigned integer indicating the total number of copies the network should ensure are stored on the network. For instance, if a blob has not yet been explicitly replicated, it would exist on 1 node, and invoking `space/blob/replicate` with `"replicas": 3` would add 2 additional replicas to the network. The invocation is idempotent: asking for `"replicas": 3` again would do nothing, leaving the total number of copies at 3.
+
+The caveats MUST include a `site` link which is a location commitment indicating where the blob is already stored. The `site` must be storing the blob on behalf of the same space. New replica locations MUST fetch the blob from this site.
 
 It is RECOMMENDED that the _Replication Service_ receiving the instruction mandate a minimum _and_ a maximum value. The minimum and maximum MAY be the same.
-
-e.g. `replicas: 2` will ensure 3 copies of the data exist in the network.
-
-The blob to be replicated and the location where the blob may be found are also required.
 
 ```json5
 {
@@ -77,7 +91,7 @@ The blob to be replicated and the location where the blob may be found are also 
           "size": 1234
         },
         /** Total number of replicas to ensure. */
-        "replicas": 2,
+        "replicas": 3,
         /** A location commitment indicating where the blob MUST be fetched from. */
         "site": { "/": "bafy..locationCommitment" }
       }
@@ -90,11 +104,11 @@ The blob to be replicated and the location where the blob may be found are also 
 
 It is RECOMMENDED that the block(s) that comprise the location commitment are included in the invocation.
 
-The receipt for `space/blob/replicate` includes effects (async tasks) for `blob/replica/transfer`. Successful completion of the `blob/replica/transfer` task indicates the replication target has transferred and stored the blob. The number of `blob/replica/transfer` tasks corresponds directly to number of replicas requested.
+The receipt for `space/blob/replicate` includes effects (async tasks) for `blob/replica/transfer`. Successful completion of the `blob/replica/transfer` task indicates the replication target has transferred and stored the blob. Each replication task MUST target a _Replica Node_, and each _Replica Node_ MUST have exactly one replication task in the effects. Thus, the number of `blob/replica/transfer` tasks will equal the number of new replicas created, which will be the `space/blob/replicate` invocation's `replicas` value minus the number of existing copies.
 
-Each replication task MUST target a _different_ _Replica Node_ and they MUST NOT target the _Primary Node_. It is RECOMMENDED that the replication tasks do not target any _Replica Nodes_ that have previously failed to replicate the data.
+The _Replication Service_ MUST select the _Storage Nodes_ which will serve as _Replica Nodes_ and instruct them to allocate replication space when the it receives the `space/blob/replicate` invocation. The set of _Replica Nodes_ MUST NOT include the _Source Node_. It SHOULD NOT include any _Storage Node_ which already stores the blob on behalf of the space, as the replication to that node will fail. It SHOULD NOT include any _Storage Node_ which has previously failed to replicate the blob, as the replication to that node is likely to fail.
 
-The _Replication Service_ MUST select _Replica Node_(s) and allocate replication space when the `space/blob/replicate` invocation is received.
+As of this writing, behavior when the `replicas` value is _less_ than the current number of copies is undefined by this specification, but expected to be defined in the future.
 
 The receipt MUST include effects (async tasks) and receipts for each allocation task performed.
 
@@ -169,10 +183,11 @@ Invocation MUST fail if any of the following is true:
 1. Provided `blob.digest` [multihash] hashing algorithm is not supported.
 1. Provided `replicas` is not an unsigned integer greater than 0 or is outside of any configured minimum or maximum value set by the _Replication Service_.
 1. Provided `site` is an invalid or revoked [location commitment].
+1. The _Replication Service_ is unable to successfully select and allocate enough _Replica Nodes_.
 
-Invocation MUST succeed if none of the above are true. Success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment], one for each replica requested.
+The invocation MUST succeed if none of the above are true. The success value MUST be an object with a `site` field set to an array of [ucan/await] of the task that produces a [location commitment], one for each replica requested.
 
-Task linked from the `site` of the success value MUST be present in the receipt effects _(`fx` field)_.
+The tasks linked from the `site` of the success value MUST be present in the receipt effects (`fx` field).
 
 ##### Blob Replicate Effects
 
@@ -215,7 +230,7 @@ The _Replication Service_ allocates replication space on _Replica Nodes_ by issu
 }
 ```
 
-The `blob/replica/allocate` task receipt MUST include an async task that will be performed by the _Replica Node_: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the _Replica Node_ has transferred the blob from its location on the _Primary Node_.
+The `blob/replica/allocate` task receipt MUST include an async task that will be performed by the _Replica Node_: `blob/replica/transfer`. The `blob/replica/transfer` task is completed when the _Replica Node_ has transferred the blob from its location on the _Source Node_.
 
 #### Blob Replica Allocate Capability Schema
 
@@ -415,7 +430,7 @@ Invocation MUST fail if any of the following is true:
 
 Invocation MUST succeed if none of the above are true.
 
-The transfer MAY fail for other reasons. For example, the _Primary Node_ is unreachable. When a transfer fails, it is up to the _Client_ to re-instruct replication tasks by issuing another `space/blob/replicate` invocation with a new [nonce](https://github.com/ucan-wg/spec/tree/v0.9.2#323-nonce). The receipt for which MUST include effects for existing non-failed replications and new replication tasks.
+The transfer MAY fail for other reasons. For example, the _Source Node_ is unreachable. When a transfer fails, it is up to the _Client_ to re-instruct replication tasks by issuing another `space/blob/replicate` invocation with a new [nonce](https://github.com/ucan-wg/spec/tree/v0.9.2#323-nonce). The receipt for which MUST include effects for existing non-failed replications and new replication tasks.
 
 #### Blob Replica Transfer Effects
 


### PR DESCRIPTION
Rework `space/blob/replicate` to count the original copy in the number of replicas, and reword things to align with that.

Most notably, I've changed "Primary Node" to "Source Node" and emphasized that it's not a property intrinsic to the node, but a description of its role in the replication operation. Curious how that looks to other folks.